### PR TITLE
Add transaction rollback in form SPARQL endpoint

### DIFF
--- a/src/main/java/org/researchspace/rest/endpoint/FormPersistenceSparqlEndpoint.java
+++ b/src/main/java/org/researchspace/rest/endpoint/FormPersistenceSparqlEndpoint.java
@@ -79,17 +79,16 @@ public class FormPersistenceSparqlEndpoint {
         logger.debug("Received SPARQL insert and delete queries: {}", deleteAndInserts);
         try {
             try (RepositoryConnection con = repositoryManager.getRepository(repositoryID).getConnection()) {
-                // TODO currently we can't execute all update operations in one transaction, see
-                // https://github.com/eclipse/rdf4j/issues/972
+                con.begin();
                 try {
                     for (String updateString : deleteAndInserts) {
                         Update update = SparqlOperationBuilder.<Update>create(updateString, Update.class)
                                 .resolveUser(nsRegistry.getUserIRI()).build(con);
                         update.execute();
                     }
+                    con.commit();
                 } catch (Exception e) {
-                    // con.rollback();
-                    // TODO it also means that we can't have rollbacks in case of error
+                    con.rollback();
                     throw e;
                 }
 


### PR DESCRIPTION
## Summary
- support transactions for multiple updates in `FormPersistenceSparqlEndpoint`

## Testing
- `./gradlew test -x testKarma --no-daemon -q` *(fails: Could not resolve all dependencies for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6844c7f2d3e08324a976ddbe9b07261d